### PR TITLE
Use NodeStatus message in  NodeStatusService

### DIFF
--- a/internal/nodestatus/service.go
+++ b/internal/nodestatus/service.go
@@ -44,12 +44,14 @@ func (s *Service) GetNodeStatus(ctx context.Context, _ *pb.GetNodeStatusRequest)
 
 	// Collect all information and return them
 	return &pb.GetNodeStatusResponse{
-		NodeId:           s.Config.NodeID,
-		NodeVersion:      s.Config.NodeVersion,
-		NodeOs:           runtime.GOOS,
-		NodeArchitecture: runtime.GOARCH,
-		Timestamp:        timestamppb.Now(),
-		StatusVersion:    currentStatus.StatusVersion,
-		Status:           anyStatus,
+		NodeStatus: &pb.NodeStatus{
+			NodeId:           s.Config.NodeID,
+			NodeVersion:      s.Config.NodeVersion,
+			NodeOs:           runtime.GOOS,
+			NodeArchitecture: runtime.GOARCH,
+			Timestamp:        timestamppb.Now(),
+			StatusVersion:    currentStatus.StatusVersion,
+			Status:           anyStatus,
+		},
 	}, nil
 }

--- a/internal/nodestatus/service_test.go
+++ b/internal/nodestatus/service_test.go
@@ -50,15 +50,17 @@ func TestNodeStatusService_GetNodeStatus(t *testing.T) {
 	status, err := service.GetNodeStatus(context.Background(), nil)
 	require.NoError(err)
 
-	require.Equal(nodeID, status.NodeId)
-	require.Equal(nodeVersion, status.NodeVersion)
-	require.Equal(runtime.GOOS, status.NodeOs)
-	require.Equal(runtime.GOARCH, status.NodeArchitecture)
-	require.NotEmpty(status.Timestamp)
-	require.Equal(statusVersion, status.StatusVersion)
+	nodeStatus := status.NodeStatus
+
+	require.Equal(nodeID, nodeStatus.NodeId)
+	require.Equal(nodeVersion, nodeStatus.NodeVersion)
+	require.Equal(runtime.GOOS, nodeStatus.NodeOs)
+	require.Equal(runtime.GOARCH, nodeStatus.NodeArchitecture)
+	require.NotEmpty(nodeStatus.Timestamp)
+	require.Equal(statusVersion, nodeStatus.StatusVersion)
 
 	resultStatusMessage := &structpb.Value{}
-	err = anypb.UnmarshalTo(status.Status, resultStatusMessage, proto.UnmarshalOptions{})
+	err = anypb.UnmarshalTo(nodeStatus.Status, resultStatusMessage, proto.UnmarshalOptions{})
 	require.NoError(err)
 
 	require.Equal(statusMessage.String(), resultStatusMessage.String())


### PR DESCRIPTION
This was forgotten when the `NodeStatus` message was split out of the `GetNodeStatusResponse`.