### PR TITLE
fixing undefined scada reference

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcp-scada-provider"
+	scada "github.com/hashicorp/hcp-scada-provider"
 	cloud "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	sdk "github.com/hashicorp/hcp-sdk-go/config"
 


### PR DESCRIPTION
Seems like with the update to Scada provider, the scada.SCADAProvider is no longer resolved without introducing the scada in the import. As a result I am getting the below error when Building Vault:
```
# github.com/hashicorp/hcp-link/pkg/config
../../go/pkg/mod/github.com/hashicorp/hcp-link@v0.0.0-20220811154050-3e9d0bfa71d3/pkg/config/config.go:7:2: imported and not used: "github.com/hashicorp/hcp-scada-provider" as provider
../../go/pkg/mod/github.com/hashicorp/hcp-link@v0.0.0-20220811154050-3e9d0bfa71d3/pkg/config/config.go:39:16: undefined: scada
../../go/pkg/mod/github.com/hashicorp/hcp-link@v0.0.0-20220811154050-3e9d0bfa71d3/pkg/config/config.go:61:24: invalid operation: c.SCADAProvider == nil (operator == not defined on untyped nil)
```