### PR TITLE
"buf mod update" googeapis dependency

### DIFF
--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,4 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 86d30bdfc34044fb9339e1bd9673839b
+    commit: 62f35d8aed1149c291d606d958a7ce32


### PR DESCRIPTION
The current version is not there in buf registry.