### PR TITLE
Security: Pin Github action versions to SHA

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,12 +16,16 @@ jobs:
     name: Run Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+
+      - name: Setup Go
+        uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
           go-version: 1.18
-      - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+
+      - name: Golangci-lint
+        uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # v3.3.1
         with:
           version: v1.49
           args: --config .golangci-lint.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,11 @@ jobs:
     name: Run Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
           cache: true
           go-version-file: 'go.mod'
@@ -32,7 +33,7 @@ jobs:
         run: make test-ci
 
       - name: Upload Coverage Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           name: Test Coverage
           path: coverage.html


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? What are the key new features or breaking changes? -->
* According to the Code Scanning warnings, we should pin the github actions to a commit SHA rather than git tag.
* Update both workflows to do so.
### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->
* https://github.com/hashicorp/hcp-link/security/code-scanning/15

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] Tests added?
- [ ] Docs updated?
